### PR TITLE
feat: check if a job already exists before rescheduling

### DIFF
--- a/inc/class-job.php
+++ b/inc/class-job.php
@@ -96,7 +96,7 @@ class Job
 	public function reschedule()
 	{
 		if ($this->isTheSameJobAlreadyScheduled()) {
-			printf('[  ] Job already scheduled, skipping rescheuduling!: %s' . PHP_EOL, $this->hook);
+			printf('[  ] Job already scheduled: %s' . PHP_EOL, $this->hook);
 			$this->update_status_to_completed();
 			return;
 		}


### PR DESCRIPTION
Sometimes jobs get duplicated runs.

Assumption:
- a job is marked as failed but didn't actually fail, and likely because the job takes more then 90% of it's reoccurrence time, which is then marked as failed, but the job actually completes.
  - WP looks up if a cron job is scheduled (marked waiting or running), it doesn't find it (because its marked as 'failed'), so it schedules a new job
  - the previous job that was marked as failed completes, and reschedules itself without checking if in the meantime WP scheduled the job again or if it was marked as failed by some other process

Solution:
- every time before a job gets rescheduled check if an existing job is already scheduled